### PR TITLE
Add further indent rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,8 +183,9 @@ module.exports = {
             4,
             {
                 'CallExpression': {
-                    arguments: 'off'
+                    arguments: 1
                 },
+                'flatTernaryExpressions': false,
                 'FunctionDeclaration': {
                     body: 1,
                     parameters: 2
@@ -192,7 +193,7 @@ module.exports = {
                 'FunctionExpression': {
                     parameters: 2
                 },
-                'MemberExpression': 'off',
+                'MemberExpression': 1,
                 'SwitchCase': 0
             }
         ],


### PR DESCRIPTION
This change adds some further indent rules that we already use anyhow, but wasn't enforced yet. Examples:

![image](https://user-images.githubusercontent.com/9974975/41362040-b0a58eaa-6f30-11e8-9a1c-fc844fd072fd.png)
![image](https://user-images.githubusercontent.com/9974975/41362088-cfb6c26e-6f30-11e8-9737-06235a4bebcf.png)
![image](https://user-images.githubusercontent.com/9974975/41362121-e3c9e4f2-6f30-11e8-95af-112556b0e96c.png)
![image](https://user-images.githubusercontent.com/9974975/41362150-ed6c14ee-6f30-11e8-9b40-fa77be08e89b.png)
