### PR TITLE
Increase max-params to 4 and max-len to 120

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ module.exports = {
         'max-len': [ 'error', 80 ],
         'max-lines': 0,
         'max-nested-callbacks': 2,
-        'max-params': 2,
+        'max-params': [ 'error', 4 ],
         'max-statements': 0,
         'max-statements-per-line': 2,
         'multiline-ternary': 0,

--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ module.exports = {
             }
         ],
         'max-depth': 2,
-        'max-len': [ 'error', 80 ],
+        'max-len': [ 'error', 120 ],
         'max-lines': 0,
         'max-nested-callbacks': 2,
         'max-params': [ 'error', 4 ],


### PR DESCRIPTION
Increasing max params from 3 (default) to 4 as some ```JitsiConferenceEvents``` callback have 4 params and it doesn't make sense to fill the code with eslint-disable annotations.

NOTE: The max-params setting format was deprecated, so the current "2" value doesn't get applied anyhow, it was the default 3.