### PR TITLE
Add enforced import order

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,6 +319,13 @@ module.exports = {
         'sort-imports': 0,
         'template-curly-spacing': 2,
         'yield-star-spacing': 2,
-        'import/no-duplicates': 2
+        'import/no-duplicates': 2,
+        'import/order': [ 'error', {
+            'alphabetize': {
+                'order': 'asc'
+            },
+            'groups': [ [ 'builtin', 'external' ], 'parent', 'sibling', 'index' ],
+            'newlines-between': 'always'
+        } ]
     }
 };


### PR DESCRIPTION
This PR adds enforced import orders to JS files.

The plugin config works almost exactly as we enforce import ordering except for one caveat: it doesn't separate imports on different levels in the file tree (it sorts them perfectly though).

E.g.:
```
import a from 'a'
import b from 'b'

import some from '../../some'
import other from '../other'

import sibling from './sibling'
```

But I think it's good enough, especially that we don't have any enforcing at the moment.