### PR TITLE
feat: include sort import members rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -307,7 +307,9 @@ module.exports = {
         'prefer-template': 2,
         'require-yield': 2,
         'rest-spread-spacing': 2,
-        'sort-imports': 0,
+        'sort-imports': [ 'error', {
+            'ignoreDeclarationSort': true
+        } ],
         'template-curly-spacing': 2,
         'yield-star-spacing': 2,
         'import/no-duplicates': 2,


### PR DESCRIPTION
- include sort import members rule for consistency in all files (seems constants variables are sorted as well and moved at the beginning, followed by the other methods)
For example: import { b,c,a, CONST_C, CONST_A } from ---> import { CONST_A, CONST_C, a,b,c }
<img width="1011" alt="Screenshot 2022-09-26 at 4 36 33 PM" src="https://user-images.githubusercontent.com/686842/192290808-74d219c0-c7ee-460d-bcc7-b5f816c4bb06.png">
